### PR TITLE
Disable fsync on postgresql to speed up tests.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     - POSTGRES_USER=django
     - POSTGRES_PASSWORD=django
     - POSTGRES_DB=django
+    # Set a few options to speed up postgresql tests.
+    command: -c fsync=off -c synchronous_commit=off -c full_page_writes=off
     volumes:
       - postgres:/var/lib/postgresql
     healthcheck:


### PR DESCRIPTION
Needs one testrun to see if it actually makes a diff, the only other option is to use a ramfs as storage.