### PR TITLE
Add unittest-xml-reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --upgrade pip
 
 COPY --chown=test:test tests/requirements/ /requirements/
 RUN for f in /requirements/*.txt; do pip install -r $f; done && \
-    pip install flake8 flake8-isort sphinx pyenchant sphinxcontrib-spelling selenium
+    pip install flake8 flake8-isort sphinx pyenchant sphinxcontrib-spelling selenium unittest-xml-reporting
 
 RUN mkdir /tests && chown -R test:test /tests
 USER test:test

--- a/settings/test_mariadb.py
+++ b/settings/test_mariadb.py
@@ -43,3 +43,6 @@ CACHES = {
         'KEY_PREFIX': '2:'
     }
 }
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_mysql.py
+++ b/settings/test_mysql.py
@@ -44,4 +44,5 @@ CACHES = {
     }
 }
 
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_mysql.py
+++ b/settings/test_mysql.py
@@ -43,3 +43,5 @@ CACHES = {
         'KEY_PREFIX': '2:'
     }
 }
+
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_mysql_gis.py
+++ b/settings/test_mysql_gis.py
@@ -29,3 +29,6 @@ PASSWORD_HASHERS = [
 ]
 
 GEOIP_PATH = '/geolite2/'
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_oracle.py
+++ b/settings/test_oracle.py
@@ -45,3 +45,6 @@ CACHES = {
         'KEY_PREFIX': '2:'
     }
 }
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_postgres.py
+++ b/settings/test_postgres.py
@@ -51,3 +51,6 @@ CACHES = {
         'KEY_PREFIX': '2:'
     }
 }
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_postgres_gis.py
+++ b/settings/test_postgres_gis.py
@@ -37,3 +37,6 @@ PASSWORD_HASHERS = [
 ]
 
 GEOIP_PATH = '/geolite2/'
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_sqlite.py
+++ b/settings/test_sqlite.py
@@ -44,3 +44,6 @@ CACHES = {
         'KEY_PREFIX': '2:'
     }
 }
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'

--- a/settings/test_sqlite_gis.py
+++ b/settings/test_sqlite_gis.py
@@ -29,3 +29,6 @@ PASSWORD_HASHERS = [
 ]
 
 GEOIP_PATH = '/geolite2/'
+
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = '/tests/django/output/'


### PR DESCRIPTION
Adds unittest-xml-reporting. This allows generating XUnit-compatible files for CI systems to consume.